### PR TITLE
chore(readme): fix path to the docker-compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can find more zcode (z5) games here: https://ifarchive.org/indexes/if-archiv
 
 * Here are some very basic instructions on how you might use this:
 
-* In a local terminal run: `cd compose/unix; docker compose up -d`
+* In a local terminal run: `cd compose; docker compose up -d`
 * Open: http://127.0.0.1:3000
 * Click: Register a new account
    * Name: admin


### PR DESCRIPTION
As per d182eb0e8d634e0eeaeff5904f958941bd7d4813 the `compose/unix/` directory is no more.
